### PR TITLE
test(main): add more test on rarely used blocks

### DIFF
--- a/tests/test.ts
+++ b/tests/test.ts
@@ -4,22 +4,37 @@ test('characters', () => {
   expect('a').not.toMatch(cjk_regex.characters());
   expect('。').not.toMatch(cjk_regex.characters());
   expect('中').toMatch(cjk_regex.characters());
+  expect('𬉼').toMatch(cjk_regex.characters());
   expect('あ').toMatch(cjk_regex.characters());
   expect('ㅂ').toMatch(cjk_regex.characters());
+  expect('가').toMatch(cjk_regex.characters());
+  expect('ퟔ').toMatch(cjk_regex.characters());
+  expect('〤').toMatch(cjk_regex.characters());
+  expect('𛀂').toMatch(cjk_regex.characters());
 });
 
 test('punctuations', () => {
   expect('a').not.toMatch(cjk_regex.punctuations());
   expect('。').toMatch(cjk_regex.punctuations());
   expect('中').not.toMatch(cjk_regex.punctuations());
+  expect('𬉼').not.toMatch(cjk_regex.punctuations());
   expect('あ').not.toMatch(cjk_regex.punctuations());
   expect('ㅂ').not.toMatch(cjk_regex.punctuations());
+  expect('가').not.toMatch(cjk_regex.punctuations());
+  expect('ퟔ').not.toMatch(cjk_regex.punctuations());
+  expect('〤').not.toMatch(cjk_regex.punctuations());
+  expect('𛀂').not.toMatch(cjk_regex.punctuations());
 });
 
 test('mixed', () => {
   expect('a').not.toMatch(cjk_regex());
   expect('。').toMatch(cjk_regex());
   expect('中').toMatch(cjk_regex());
-  expect('あ').toMatch(cjk_regex());
-  expect('ㅂ').toMatch(cjk_regex());
+  expect('𬉼').toMatch(cjk_regex())
+  expect('あ').toMatch(cjk_regex())
+  expect('ㅂ').toMatch(cjk_regex())
+  expect('가').toMatch(cjk_regex())
+  expect('ퟔ').toMatch(cjk_regex())
+  expect('〤').toMatch(cjk_regex())
+  expect('𛀂').toMatch(cjk_regex())
 });


### PR DESCRIPTION
Added more test samples on rarely used blocks.

It should reveal the following questions:

- The Hangul Syllable should not be categorized as punctuations.
- The Following blocks should be letters/Number letters.
   - Jamo Extended B
   - Hentaigana
   - CJK Ideograph Extension B..F
   - Hangzhou Numerals