### PR TITLE
fix: disallow whitespace between ideographic description characters and 

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ const cjk_punctuations = unicode({
     'CJK_Compatibility_Forms',
     'Small_Form_Variants',
     'Halfwidth_And_Fullwidth_Forms',
-    'Ideographic_Description_Characters'
+    'Ideographic_Description_Characters',
   ],
 }).subtract(cjk_letters);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ const cjk_punctuations = unicode({
     'CJK_Compatibility_Forms',
     'Small_Form_Variants',
     'Halfwidth_And_Fullwidth_Forms',
+    'Ideographic_Description_Characters'
   ],
 }).subtract(cjk_letters);
 

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -6,6 +6,7 @@ const test_cases: {
   '.': 'non-cjk',
   'a': 'non-cjk',
   '。': 'cjk-punctuation',
+  '⿱': 'cjk-punctuation',
   '中': 'cjk-letter',
   'ㄅ': 'cjk-letter',
   '𬉼': 'cjk-letter',


### PR DESCRIPTION
This PR disallows the whitespace inserted by `prettier` between [ideographic description characters](http://en.wikipedia.org/wiki/Ideographic_Description_Characters_(Unicode_block)), or IDC and Hànzì.

The ideographic description characters are used to describe the shape of Hànzì. Generally whitespaces are not used between IDC and Hànzì. For example: https://www.babelstone.co.uk/CJK/IDS.TXT