### PR TITLE
Add `types` to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,10 @@
     "cjk",
     "regular-expression"
   ],
-  "exports": "./lib/index.js",
-  "types": "./lib/index.d.ts",
+  "exports": {
+    "types": "./lib/index.d.ts",
+    "default":"./lib/index.js"
+  },
   "repository": "https://github.com/ikatyang/cjk-regex",
   "homepage": "https://github.com/ikatyang/cjk-regex#readme",
   "author": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "regular-expression"
   ],
   "exports": "./lib/index.js",
+  "types": "./lib/index.d.ts",
   "repository": "https://github.com/ikatyang/cjk-regex",
   "homepage": "https://github.com/ikatyang/cjk-regex#readme",
   "author": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "exports": {
     "types": "./lib/index.d.ts",
-    "default":"./lib/index.js"
+    "default": "./lib/index.js"
   },
   "repository": "https://github.com/ikatyang/cjk-regex",
   "homepage": "https://github.com/ikatyang/cjk-regex#readme",


### PR DESCRIPTION
When I tried to import this package in my typescript project, I got the following error:

> Cannot find module 'cjk-regex' or its corresponding type declarations.

Following https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#including-declarations-in-your-npm-package, I added `type` to `package.json` and it resolved the error.
